### PR TITLE
Ignoring an error if an extension is not found in a binary file

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,11 @@ class EasyYandexS3 {
 			if(file.name) file_upload_name = file.name;
 		}else{
 			file_body = file.buffer;
-			file_ext = '.'+fileType(file_body).ext;
+			try {
+				file_ext = '.'+fileType(file_body).ext;
+			} catch (error) {
+				if (debug) this._log("S3", debug_object,'error:', error);
+			}
 			if(file.name) file_upload_name = file.name;
 		}
 	


### PR DESCRIPTION
When passing a file to `S3.Upload()` with the buffer parameter, the fileType module does not always correctly determine the file extension. For example, for .txt and .dll - it throws an unhandled error.