### PR TITLE
fixing ContentType

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,8 @@ class EasyYandexS3 {
 		
 		var s3 = this.s3;
 		var Bucket = this.Bucket;
-		var params = {Bucket, Key, Body, ContentType: mime.lookup(file_upload_name)}
+		var ContentType = ContentType: mime.lookup(file_upload_name) || "text/plain";
+		var params = {Bucket, Key, Body, ContentType}
 
 		if(debug) this._log("S3", debug_object, "started");
 		if(debug) this._log("S3", debug_object, params);


### PR DESCRIPTION
Привет, столкнулся с проблемой, что не все расширения можно загружать
если ContentType становится false, то в последнем catch вылетает ошибка
по сути в ContentType просто пишется, к чему этот документ относится, мне на pdf туда записалось "application/pdf"
решение в строку - если false, то дописываю "plain/text", теперь работает с остальными расширениями (.sln, .key)