### PR TITLE
From MD5 names to UUID name

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ var s3 = new EasyYandexS3({
 ```
 
 - Загрузка по расположению файла  
-  123.png -> [bucket-name]/test/07af8a67f6a4fa5f65a7f687a98fa6f2a34f.png
+  123.png -> [bucket-name]/test/d20e9d31-8eab-4618-aa1d-12dedc794356.png
 
 ```javascript
 var upload = await s3.Upload(
@@ -128,7 +128,7 @@ var upload = await s3.Upload(
 );
 console.log(upload); // <- Возвращает путь к файлу в хранилище и всякую дополнительную информацию.
 // если вернулся false - произошла ошибка
-// Файл загрузится в [my-stogare]/test/{md5_сумма}.{расширение}
+// Файл загрузится в [my-stogare]/test/{uuid-v4}.{расширение}
 ```
 
 - Загрузка по расположению файла, с указанием оригинального имени и расширения файла  
@@ -164,7 +164,7 @@ console.log(upload); // <- Возвращает путь к файлу в хра
 ```
 
 - Загрузка буфера  
-  <Buffer> -> [bucket-name]/test/cad9c7a68dca57ca6dc9a7dc8a86c.png
+  <Buffer> -> [bucket-name]/test/d20e9d31-8eab-4618-aa1d-12dedc794356.png
 
 ```javascript
 var upload = await s3.Upload(
@@ -175,7 +175,7 @@ var upload = await s3.Upload(
 );
 console.log(upload); // <- Возвращает путь к файлу в хранилище и всякую дополнительную информацию.
 // если вернулся false - произошла ошибка
-// Файл загрузится в [my-stogare]/test/{md5_сумма}.{расширение}
+// Файл загрузится в [my-stogare]/test/{uuid-v4}.{расширение}
 ```
 
 - Загрузка буфера с определением имени и расширения файла  
@@ -278,7 +278,7 @@ console.log(upload); // <- массив загруженных файлов
 var upload = await s3.Upload(
   [
     { path: './file1.jpg', save_name: true }, // относительный путь до файла с сохранением имени
-    { path: '/Users/powerodt/dev/sites/folder/file2.css' }, // прямой путь до файла с изменением имени на md5-сумму
+    { path: '/Users/powerodt/dev/sites/folder/file2.css' }, // прямой путь до файла с изменением имени на uuid-v4
     { path: './file.html', name: 'index.html' }, // относительный путь на файл с изменением имени при загрузке на index.html
   ],
   '/folder_on_server/'

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const AWS = require('aws-sdk');
-const md5 = require('md5');
+const { v4: uuidv4 } = require('uuid');
 const fs = require('fs');
 const path = require('path');
 const mime = require('mime-types');
@@ -116,8 +116,8 @@ class EasyYandexS3 {
     if (route[0] === '/') route = route.slice(1);
 
     if (!fileUploadName) {
-      const fileMd5 = md5(fileBody);
-      fileUploadName = `${fileMd5}${fileExt}`;
+      const uniqueName = uuidv4();
+      fileUploadName = `${uniqueName}${fileExt}`;
     }
 
     const uploadRoute = route;

--- a/package.json
+++ b/package.json
@@ -32,9 +32,8 @@
   "dependencies": {
     "aws-sdk": "^2.493.0",
     "file-type": "^12.0.1",
-    "md5": "^2.2.1",
     "mime-types": "^2.1.24",
-    "uniqid": "^5.0.3"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/test/methods/upload.spec.js
+++ b/test/methods/upload.spec.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 
 const s3 = require('../s3');
 
+const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
 describe('Upload', function () {
   this.timeout(20000);
 
@@ -47,16 +49,16 @@ describe('Upload', function () {
     const keyParts = u.Key.split(/[/.]+/);
     const [folderS3, filenameS3, fileExtensionS3] = keyParts;
 
-    const isChecksum = !!filenameS3.match(/^[0-9a-f]{32}$/);
+    const isUuid = !!filenameS3.match(uuidRegex);
 
-    expect(isChecksum).to.be.equal(true);
+    expect(isUuid).to.be.equal(true);
     expect(folderS3).to.be.equal(uploadFolder.slice(1, -1));
     expect(fileExtensionS3).to.be.equal(fileExtension);
 
     await s3.CleanUp();
   });
 
-  it('upload array of files with md5 names', async () => {
+  it('upload array of files with uuid names', async () => {
     const uploadFolder = '/eys3-testing/';
     const fileExtension = 'rtf';
 
@@ -71,9 +73,9 @@ describe('Upload', function () {
       const keyParts = result.Key.split(/[/.]+/);
       const [folderS3, filenameS3, fileExtensionS3] = keyParts;
 
-      const isChecksum = !!filenameS3.match(/^[0-9a-f]{32}$/);
+      const isUuid = !!filenameS3.match(uuidRegex);
 
-      expect(isChecksum).to.be.equal(true);
+      expect(isUuid).to.be.equal(true);
       expect(folderS3).to.be.equal(uploadFolder.slice(1, -1));
       expect(fileExtensionS3).to.be.equal(fileExtension);
     });
@@ -81,9 +83,7 @@ describe('Upload', function () {
     await s3.CleanUp();
   });
 
-  // this test doesn't work correctly with files that have same content because of md5
-  // it's override files with same content(or only same extension and content)
-  it('upload full folder with relative path with md5 names', async () => {
+  it('upload full folder with relative path with uuid names', async () => {
     const uploadFolder = '/eys3-testing/';
     const subfolder = 'folder1';
     const fileExtension = 'rtf';
@@ -110,9 +110,9 @@ describe('Upload', function () {
         [folderS3, filenameS3, fileExtensionS3] = keyParts;
       }
 
-      const isChecksum = !!filenameS3.match(/^[0-9a-f]{32}$/);
+      const isUuid = !!filenameS3.match(uuidRegex);
 
-      expect(isChecksum).to.be.equal(true);
+      expect(isUuid).to.be.equal(true);
       expect(folderS3).to.be.equal(uploadFolder.slice(1, -1));
       expect(fileExtensionS3).to.be.equal(fileExtension);
 


### PR DESCRIPTION
Hey, @powerdot!
We've got a bug with `md5` names.

### How this bug works (bug, works😂)
We want to upload two files with same content -> we've got same buffers -> we've got a collision when we compute md5 checksum base on this buffer -> one file replace another with same name -> only one file is uploaded successfully.

### Suggetion
My suggestion is to use `uuid` for random name generation. We can actully use `md5` on filenames but I think checksum is for file protection/safety first and secondly may be for random strings. Project already has a `uniqid` dependency but I switch it for `uuid` (rfc, popularity).

### To do list
- [x] Make changes for 'Upload' method to give files `uuid` names
- [x] Update tests for 'Upload' method 
- [x] Update docs for changing names from `md5` to `uuid`

P.S. We can do a release after merging this pull request. I can create a release on github to point out changes of last updates. 
P.S.S. Инглиш в деле😎
